### PR TITLE
fixing description of Trampoline changes

### DIFF
--- a/17.md
+++ b/17.md
@@ -60,8 +60,8 @@ Many core modules have been moved out into separate packages, usually under `elm
 * `Graphics` is now in `evancz/elm-graphics`
 * `Trampoline` is now in `elm-lang/trampoline` and has some renames
   * `Trampoline.trampoline` is now `Trampoline.evaluate`
-  * `Trampoline.Done` is now `Trampoline.done` (function instead of type)
-  * `Trampoline.Continue` is now `Trampoline.continue` (function instead of type)
+  * `Trampoline.Done` is now `Trampoline.done` (function instead of constructor)
+  * `Trampoline.Continue` is now `Trampoline.jump` (function instead of constructor)
 * `Mouse` is now in `elm-lang/mouse`
 * `Window` is now in `elm-lang/window`
 * `Keyboard` is now in `elm-lang/keyboard`


### PR DESCRIPTION
- Neither `Trampoline.Done` nor `Trampoline.Continue` was a "type".
- The new name for `Trampoline.Continue` is `Trampoline.jump`.
