### PR TITLE
Update creating a new `Cmd` for a given message

### DIFF
--- a/17.md
+++ b/17.md
@@ -123,30 +123,21 @@ For example, you now need `module Foo exposing (..)` where prior to Elm 0.17 you
 
 ### How do I generate a new message as a command?
 
-Sending a new message this way is often not necessary. The same effect can often be had by calling the update function recursively with the new message.
-The functions in the
-[ccapndave/elm-update-extra](http://package.elm-lang.org/packages/ccapndave/elm-update-extra/latest) package aid in doing that, chaining several messages and related update actions together.
-
-
-That said, you can send the `Test` message to yourself with this:
+The package [shmookey/cmd-extra](http://package.elm-lang.org/packages/shmookey/cmd-extra/latest) provides a function to construct a `Cmd` yielding an arbitrary value:
 
 ```haskell
-Task.perform (\_ -> (Debug.crash "fail")) identity (Task.succeed Test)
+message : msg -> Cmd msg
 ```
 
-Alternatively, you can use the fact that the failure case should not happen for `Task.succeed` like this:
+However, this is often unnecessary. To handle a message produced by a call to `update` you may pass it straight back to `update` recursively. The package [ccapndave/elm-update-extra](http://package.elm-lang.org/packages/ccapndave/elm-update-extra/latest) provides helper functions for implementing this approach elegantly. 
+
+The latter approach is likely to be more efficient in most cases. The former option may be attractive when recursive calls to `update` could cause an infinite loop, or for authors of reusable components interested in creating a clean encapsulation of their library's internal behaviour.
+
+Without using any libraries, you may simply create and perform a task that always succeeds with a given message:
 
 ```haskell
-Task.perform identity identity (Task.succeed Test)
+Task.perform (\_ -> Debug.crash "This failure cannot happen.") identity (Task.succeed Test)
 ```
-
-There is also the `performFailproof` function in [NoRedInk/elm-task-extra](http://package.elm-lang.org/packages/NoRedInk/elm-task-extra/latest):
-
-```haskell
-Task.Extra.performFailproof identity (Task.succeed Test)
-```
-
-
 
 ### Are static ports still available?
 


### PR DESCRIPTION
The original answer first described an alternative (recursive) approach that may be appropriate in some situations, then gave code for three different but equivalent solutions to the actual question. 

The updated answer points to the helper function in `Cmd.Extra` first, then describes the recursive solution, briefly compares the two and concludes by demonstrating how the same effect may be achieved without using libraries. 

I've only kept the first and ugliest of the three code samples here because it's the most conceptually simple and doesn't require understanding how type safety interacts with uninhabited types. Now that `Cmd.Extra.message` exists, users can look at that for a more elegant solution if they are interested.
